### PR TITLE
Add missing elapse command to HelpCommand console help text

### DIFF
--- a/src/main/java/dansapps/interakt/commands/multi/HelpCommand.java
+++ b/src/main/java/dansapps/interakt/commands/multi/HelpCommand.java
@@ -38,6 +38,7 @@ public class HelpCommand extends InteraktCommand {
             sender.sendMessage("info - View information about the application.");
             sender.sendMessage("stats - View statistics about the application.");
             sender.sendMessage("wipe - Wipe the data of the application.");
+            sender.sendMessage("elapse - Force time to elapse within the application.");
             sender.sendMessage("quit - Quit the application.");
         }
         else if (sender instanceof Player) {

--- a/src/main/java/dansapps/interakt/tests/HelpCommandTest.java
+++ b/src/main/java/dansapps/interakt/tests/HelpCommandTest.java
@@ -1,0 +1,35 @@
+package dansapps.interakt.tests;
+
+import dansapps.interakt.commands.multi.HelpCommand;
+import dansapps.interakt.users.Console;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HelpCommandTest {
+
+    @Test
+    public void testConsoleHelpTextIncludesElapseCommand() {
+        List<String> messages = new ArrayList<>();
+        Console console = new Console() {
+            @Override
+            public void sendMessage(String message) {
+                messages.add(message);
+            }
+        };
+
+        HelpCommand helpCommand = new HelpCommand();
+        helpCommand.execute(console);
+
+        boolean foundElapseLine = false;
+        for (String message : messages) {
+            if (message.startsWith("elapse - ")) {
+                foundElapseLine = true;
+                break;
+            }
+        }
+        Assert.assertTrue(foundElapseLine);
+    }
+}


### PR DESCRIPTION
## Summary

- The `elapse` command was found registered in `Interakt.java#getCommands()` (`commands.add(new ElapseCommand(timeService))`) and reachable by console users, yet it was absent from `HelpCommand`'s console help output — the one console command left out of that list.
- A line for `elapse` was added to the console branch of `HelpCommand.execute`, matching the style of the surrounding lines.
- A regression test (`HelpCommandTest`) was added, asserting the console help output includes a line for `elapse`. It was confirmed to fail against the pre-fix code and pass against the fix (stash-and-run).

## Test plan

- [x] `mvn -o clean package` run locally — BUILD SUCCESS, 9/9 tests passed (up from 8, new `HelpCommandTest` included).
- [x] Regression evidence gathered empirically: `HelpCommand.java`'s fix was stashed, `HelpCommandTest` was re-run and observed to FAIL, then the fix was restored and the test was observed to PASS.

Closes #99

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->