### PR TITLE
fix: grant the interakt.info permission to Console

### DIFF
--- a/src/main/java/dansapps/interakt/tests/ConsolePermissionsTest.java
+++ b/src/main/java/dansapps/interakt/tests/ConsolePermissionsTest.java
@@ -1,0 +1,88 @@
+package dansapps.interakt.tests;
+
+import dansapps.interakt.commands.console.CreateCommand;
+import dansapps.interakt.commands.console.DeleteCommand;
+import dansapps.interakt.commands.console.ElapseCommand;
+import dansapps.interakt.commands.console.GenerateTestDataCommand;
+import dansapps.interakt.commands.console.InfoCommand;
+import dansapps.interakt.commands.console.ListCommand;
+import dansapps.interakt.commands.console.PlaceCommand;
+import dansapps.interakt.commands.console.RelationsCommand;
+import dansapps.interakt.commands.console.StatsCommand;
+import dansapps.interakt.commands.console.ViewCommand;
+import dansapps.interakt.commands.console.WipeCommand;
+import dansapps.interakt.commands.multi.HelpCommand;
+import dansapps.interakt.commands.multi.QuitCommand;
+import dansapps.interakt.commands.multi.SaveCommand;
+import dansapps.interakt.services.LocalCommandService;
+import dansapps.interakt.users.Console;
+import org.junit.Assert;
+import org.junit.Test;
+import preponderous.ponder.system.abs.ApplicationCommand;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+public class ConsolePermissionsTest {
+
+    /**
+     * The commands a console user is expected to be able to invoke. These mirror the registrations in
+     * Interakt#getCommands(). Their collaborators are only assigned by the constructors, so null is
+     * sufficient here — no command is executed by the parity test, only its permission is read.
+     */
+    private List<ApplicationCommand> getConsoleCommands() {
+        return List.of(
+                new HelpCommand(),
+                new InfoCommand(),
+                new QuitCommand(null),
+                new CreateCommand(null, null),
+                new DeleteCommand(null),
+                new ViewCommand(null),
+                new ListCommand(null),
+                new PlaceCommand(null),
+                new StatsCommand(null, null),
+                new WipeCommand(null),
+                new ElapseCommand(null),
+                new SaveCommand(null),
+                new GenerateTestDataCommand(null, null, null),
+                new RelationsCommand(null)
+        );
+    }
+
+    @Test
+    public void testConsoleHasPermissionForEveryConsoleCommand() {
+        Console console = new Console();
+
+        List<String> missingPermissions = new ArrayList<>();
+        for (ApplicationCommand command : getConsoleCommands()) {
+            String permission = command.getPermissions().get(0);
+            if (!console.hasPermission(permission)) {
+                missingPermissions.add(permission);
+            }
+        }
+
+        Assert.assertEquals("Console is missing permissions: " + missingPermissions, 0, missingPermissions.size());
+    }
+
+    @Test
+    public void testInfoCommandIsExecutableByConsole() {
+        List<String> messages = new ArrayList<>();
+        Console console = new Console() {
+            @Override
+            public void sendMessage(String message) {
+                messages.add(message);
+            }
+        };
+
+        HashSet<ApplicationCommand> commands = new HashSet<>();
+        commands.add(new InfoCommand());
+        LocalCommandService commandService = new LocalCommandService(commands);
+
+        boolean success = commandService.interpretCommand(console, "info", new String[0]);
+
+        Assert.assertTrue(success);
+        Assert.assertTrue(messages.contains("=== Interakt Info ==="));
+        Assert.assertFalse(messages.contains("You don't have permission to use this command."));
+    }
+}

--- a/src/main/java/dansapps/interakt/users/Console.java
+++ b/src/main/java/dansapps/interakt/users/Console.java
@@ -14,6 +14,7 @@ public class Console extends CommandSenderImpl {
         addPermission("interakt.elapse");
         addPermission("interakt.generatetestdata");
         addPermission("interakt.help");
+        addPermission("interakt.info");
         addPermission("interakt.list");
         addPermission("interakt.place");
         addPermission("interakt.quit");


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- `interakt.info` is now granted in the `Console` constructor. The `info` command was registered in `Interakt#getCommands()` and advertised by `HelpCommand`'s console help text, but `Console` never held its permission, so `LocalCommandService#interpretCommand` answered with `You don't have permission to use this command.` instead of running it.
- `ConsolePermissionsTest` is added. Two behaviours are covered: every command registered for console use has its permission granted to `Console`, and `info` is executed end-to-end through `LocalCommandService` with a `Console` sender. The first of these guards against a future command being registered without a matching permission grant.

The console commands in the parity test are constructed with `null` collaborators. This is safe because every one of those constructors only assigns its fields, and no command is executed by that test — only `getPermissions()` is read.

## Test plan

- [x] `mvn -B clean test` — 11 tests, 0 failures, 0 errors (9 before this change).
- [x] Regression confirmed empirically: with the `Console.java` change stashed, both new tests fail (`Console is missing permissions: [interakt.info] expected:<0> but was:<1>`, and the end-to-end `info` assertion). With the change restored, both pass.

## Deferred this cycle

The remaining open issues were not picked up here, so that this change stays scoped to one bug:

- #103 (no test coverage for `Actor`'s health and relationship logic) — deferred as a cohesive test-expansion cycle of its own.
- #104 (per-file Apache-2.0 headers contradict the Stephenson-NC `LICENSE`) — deferred because the licensing text is a decision for the repository owner rather than something to be rewritten autonomously.

Closes #102

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_